### PR TITLE
ENH: Add Linux and macOS aarch64 and ppc64le builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,22 @@ jobs:
         CONFIG: linux_64_pythia88.312
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_pythia88.311:
+        CONFIG: linux_aarch64_pythia88.311
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_pythia88.312:
+        CONFIG: linux_aarch64_pythia88.312
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_pythia88.311:
+        CONFIG: linux_ppc64le_pythia88.311
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_pythia88.312:
+        CONFIG: linux_ppc64le_pythia88.312
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,0 +1,40 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+jobs:
+- job: osx
+  pool:
+    vmImage: macOS-15
+  strategy:
+    matrix:
+      osx_arm64_pythia88.311:
+        CONFIG: osx_arm64_pythia88.311
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_pythia88.312:
+        CONFIG: osx_arm64_pythia88.312
+        UPLOAD_PACKAGES: 'True'
+  timeoutInMinutes: 360
+  variables: {}
+
+  steps:
+  # TODO: Fast finish on azure pipelines?
+  - script: |
+      export CI=azure
+      export flow_run_id=azure_$(Build.BuildNumber).$(System.JobAttempt)
+      export remote_url=$(Build.Repository.Uri)
+      export sha=$(Build.SourceVersion)
+      export OSX_FORCE_SDK_DOWNLOAD="1"
+      export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
+        export IS_PR_BUILD="True"
+      else
+        export IS_PR_BUILD="False"
+      fi
+      ./.scripts/run_osx_build.sh
+    displayName: Run OSX build
+    env:
+      BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+      FEEDSTOCK_TOKEN: $(FEEDSTOCK_TOKEN)
+      STAGING_BINSTAR_TOKEN: $(STAGING_BINSTAR_TOKEN)

--- a/.ci_support/linux_aarch64_pythia88.311.yaml
+++ b/.ci_support/linux_aarch64_pythia88.311.yaml
@@ -1,0 +1,20 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pythia8:
+- '8.311'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_aarch64_pythia88.312.yaml
+++ b/.ci_support/linux_aarch64_pythia88.312.yaml
@@ -1,0 +1,20 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pythia8:
+- '8.312'
+target_platform:
+- linux-aarch64

--- a/.ci_support/linux_ppc64le_pythia88.311.yaml
+++ b/.ci_support/linux_ppc64le_pythia88.311.yaml
@@ -1,0 +1,20 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pythia8:
+- '8.311'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/linux_ppc64le_pythia88.312.yaml
+++ b/.ci_support/linux_ppc64le_pythia88.312.yaml
@@ -1,0 +1,20 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '14'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+pythia8:
+- '8.312'
+target_platform:
+- linux-ppc64le

--- a/.ci_support/osx_arm64_pythia88.311.yaml
+++ b/.ci_support/osx_arm64_pythia88.311.yaml
@@ -1,0 +1,22 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+pythia8:
+- '8.311'
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_pythia88.312.yaml
+++ b/.ci_support/osx_arm64_pythia88.312.yaml
@@ -1,0 +1,22 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '19'
+macos_machine:
+- arm64-apple-darwin20.0.0
+pythia8:
+- '8.312'
+target_platform:
+- osx-arm64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  rattler-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -48,6 +58,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+# -*- mode: jinja-shell -*-
+
+source .scripts/logging_utils.sh
+
+set -xe
+
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
+( startgroup "Provisioning base env with pixi" ) 2> /dev/null
+mkdir -p "${MINIFORGE_HOME}"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak "s/platforms = .*/platforms = [\"osx-${arch}\"]/" pixi.toml
+echo "Creating environment"
+pixi install
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook)"
+mv pixi.toml.bak pixi.toml
+( endgroup "Provisioning base env with pixi" ) 2> /dev/null
+
+( startgroup "Configuring conda" ) 2> /dev/null
+export CONDA_SOLVER="libmamba"
+export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
+
+
+
+
+
+echo -e "\n\nSetting up the condarc and mangling the compiler."
+setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+
+if [[ "${CI:-}" != "" ]]; then
+  mangle_compiler ./ ./recipe .ci_support/${CONFIG}.yaml
+fi
+
+if [[ "${CI:-}" != "" ]]; then
+  echo -e "\n\nMangling homebrew in the CI to avoid conflicts."
+  /usr/bin/sudo mangle_homebrew
+  /usr/bin/sudo -k
+else
+  echo -e "\n\nNot mangling homebrew as we are not running in CI"
+fi
+
+if [[ "${sha:-}" == "" ]]; then
+  sha=$(git rev-parse HEAD)
+fi
+
+echo -e "\n\nRunning the build setup script."
+source run_conda_forge_build_setup
+
+
+
+( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f LICENSE.txt ]]; then
+  cp LICENSE.txt "recipe/recipe-scripts-license.txt"
+fi
+
+if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
+    echo "rattler-build does not currently support debug mode"
+else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
+    fi
+
+    rattler-build build --recipe ./recipe \
+        -m ./.ci_support/${CONFIG}.yaml \
+        ${EXTRA_CB_OPTIONS:-} \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="$flow_run_id" \
+        --extra-meta remote_url="$remote_url" \
+        --extra-meta sha="$sha"
+
+    ( startgroup "Inspecting artifacts" ) 2> /dev/null
+
+    # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4
+    command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts --recipe-dir ./recipe -m ./.ci_support/${CONFIG}.yaml || echo "inspect_artifacts needs conda-forge-ci-setup >=4.9.4"
+
+    ( endgroup "Inspecting artifacts" ) 2> /dev/null
+    ( startgroup "Validating outputs" ) 2> /dev/null
+
+    validate_recipe_outputs "${FEEDSTOCK_NAME}"
+
+    ( endgroup "Validating outputs" ) 2> /dev/null
+
+    ( startgroup "Uploading packages" ) 2> /dev/null
+
+    if [[ "${UPLOAD_PACKAGES}" != "False" ]] && [[ "${IS_PR_BUILD}" == "False" ]]; then
+      upload_package --validate --feedstock-name="${FEEDSTOCK_NAME}" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+    fi
+
+    ( endgroup "Uploading packages" ) 2> /dev/null
+fi

--- a/README.md
+++ b/README.md
@@ -42,6 +42,48 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mg5amcnlo-pythia8-interface-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_pythia88.312" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>linux_aarch64_pythia88.311</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26608&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mg5amcnlo-pythia8-interface-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_pythia88.311" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_pythia88.312</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26608&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mg5amcnlo-pythia8-interface-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_pythia88.312" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_pythia88.311</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26608&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mg5amcnlo-pythia8-interface-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_pythia88.311" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_pythia88.312</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26608&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mg5amcnlo-pythia8-interface-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_pythia88.312" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_pythia88.311</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26608&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mg5amcnlo-pythia8-interface-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_pythia88.311" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_pythia88.312</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=26608&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/mg5amcnlo-pythia8-interface-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_pythia88.312" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,3 +29,4 @@ stages:
   dependsOn: Check
   jobs:
     - template: ./.azure-pipelines/azure-pipelines-linux.yml
+    - template: ./.azure-pipelines/azure-pipelines-osx.yml

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,16 @@
 conda_build_tool: rattler-build
-github:
-  branch_name: main
-  tooling_branch_name: main
+conda_install_tool: pixi
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+  osx_arm64: osx_64
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+github:
+  branch_name: main
+  tooling_branch_name: main
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,96 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "mg5amcnlo-pythia8-interface-feedstock"
+version = "3.52.2"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/mg5amcnlo-pythia8-interface-feedstock"
+authors = ["@conda-forge/mg5amcnlo-pythia8-interface"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build mg5amcnlo-pythia8-interface-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_pythia88.311"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_pythia88.311.yaml"
+description = "Build mg5amcnlo-pythia8-interface-feedstock with variant linux_64_pythia88.311 directly (without setup scripts)"
+[tasks."inspect-linux_64_pythia88.311"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_pythia88.311.yaml"
+description = "List contents of mg5amcnlo-pythia8-interface-feedstock packages built for variant linux_64_pythia88.311"
+[tasks."build-linux_64_pythia88.312"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_pythia88.312.yaml"
+description = "Build mg5amcnlo-pythia8-interface-feedstock with variant linux_64_pythia88.312 directly (without setup scripts)"
+[tasks."inspect-linux_64_pythia88.312"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_pythia88.312.yaml"
+description = "List contents of mg5amcnlo-pythia8-interface-feedstock packages built for variant linux_64_pythia88.312"
+[tasks."build-linux_aarch64_pythia88.311"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_pythia88.311.yaml"
+description = "Build mg5amcnlo-pythia8-interface-feedstock with variant linux_aarch64_pythia88.311 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_pythia88.311"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_pythia88.311.yaml"
+description = "List contents of mg5amcnlo-pythia8-interface-feedstock packages built for variant linux_aarch64_pythia88.311"
+[tasks."build-linux_aarch64_pythia88.312"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_pythia88.312.yaml"
+description = "Build mg5amcnlo-pythia8-interface-feedstock with variant linux_aarch64_pythia88.312 directly (without setup scripts)"
+[tasks."inspect-linux_aarch64_pythia88.312"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_pythia88.312.yaml"
+description = "List contents of mg5amcnlo-pythia8-interface-feedstock packages built for variant linux_aarch64_pythia88.312"
+[tasks."build-linux_ppc64le_pythia88.311"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_pythia88.311.yaml"
+description = "Build mg5amcnlo-pythia8-interface-feedstock with variant linux_ppc64le_pythia88.311 directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_pythia88.311"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_pythia88.311.yaml"
+description = "List contents of mg5amcnlo-pythia8-interface-feedstock packages built for variant linux_ppc64le_pythia88.311"
+[tasks."build-linux_ppc64le_pythia88.312"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_pythia88.312.yaml"
+description = "Build mg5amcnlo-pythia8-interface-feedstock with variant linux_ppc64le_pythia88.312 directly (without setup scripts)"
+[tasks."inspect-linux_ppc64le_pythia88.312"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_pythia88.312.yaml"
+description = "List contents of mg5amcnlo-pythia8-interface-feedstock packages built for variant linux_ppc64le_pythia88.312"
+[tasks."build-osx_arm64_pythia88.311"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_pythia88.311.yaml"
+description = "Build mg5amcnlo-pythia8-interface-feedstock with variant osx_arm64_pythia88.311 directly (without setup scripts)"
+[tasks."inspect-osx_arm64_pythia88.311"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_pythia88.311.yaml"
+description = "List contents of mg5amcnlo-pythia8-interface-feedstock packages built for variant osx_arm64_pythia88.311"
+[tasks."build-osx_arm64_pythia88.312"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_pythia88.312.yaml"
+description = "Build mg5amcnlo-pythia8-interface-feedstock with variant osx_arm64_pythia88.312 directly (without setup scripts)"
+[tasks."inspect-osx_arm64_pythia88.312"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_pythia88.312.yaml"
+description = "List contents of mg5amcnlo-pythia8-interface-feedstock packages built for variant osx_arm64_pythia88.312"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+shellcheck = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,5 @@
+# c.f. https://github.com/conda-forge/staged-recipes/issues/27750 for why not
+# currently using variants.yaml
 pythia8:
 - "8.311"
 - "8.312"

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 66055e0faac2c1ab0b0bb9d98cf88d80e79040be7d6d27dfb8964b141b802203
 
 build:
-  number: 0
+  number: 1
   skip:
     - win
     # PY8_parallelization is broken on osx-64
@@ -43,6 +43,9 @@ requirements:
     - ${{ stdlib('c') }}
     - ${{ compiler('cxx') }}
     - make
+    - if: build_platform != target_platform
+      then:
+        - python
   host:
     - hepmc2
     - pythia8  # variant


### PR DESCRIPTION
* Add linux-aarch64, linux-ppc64le, and macos-arm64 build support.
   - Add cross-platform python emulation support (only need interpreter).
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
