### PR TITLE
FIX: Set correct rpath for osx-arm64

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -86,6 +86,7 @@ tests:
         - share/mg5amcnlo_pythia8_interface/COMPATIBILITY
         - share/mg5amcnlo_pythia8_interface/MG5AMC_VERSION_ON_INSTALL
         - share/mg5amcnlo_pythia8_interface/PYTHIA8_VERSION_ON_INSTALL
+        - share/mg5amcnlo_pythia8_interface/*.dat
 
         - MG5_aMC/HEPTools/MG5aMC_PY8_interface/MG5aMC_PY8_interface
         - MG5_aMC/HEPTools/MG5aMC_PY8_interface/VERSION

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -87,7 +87,6 @@ tests:
       # Somehow downloading in advance causes a compilation error on x86 Linux only in CI
       - lhapdf install NNPDF23_lo_as_0130_qed &> download_log.txt
       - mg5_aMC pythia8_test.mg5
-      - cat PYTHIA8_INTERFACE_MG5_RUN/run_01_tag_1_debug.log
 
 about:
   # modified University of Illinois/NCSA license

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,13 +13,16 @@ source:
   sha256: 66055e0faac2c1ab0b0bb9d98cf88d80e79040be7d6d27dfb8964b141b802203
 
 build:
-  number: 3
+  number: 4
   skip:
     - win
     # PY8_parallelization is broken on osx-64
     - osx and x86_64
   script:
     # Manually compile MG5aMC_PY8_interface.cc instead of using compile.py
+    - echo "DEBUG DEBUG"
+    - echo "$CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS $(pythia8-config --cxxflags) $LDFLAGS $(pythia8-config --ldflags) -lHepMC"
+    - echo "DEBUG DEBUG"
     - $CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS $(pythia8-config --cxxflags) $LDFLAGS $(pythia8-config --ldflags) -lHepMC
     - echo "UNSPECIFIED" > MG5AMC_VERSION_ON_INSTALL
     # pythia8-config --version added in 8.312, so fall back to

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,8 +21,8 @@ build:
   script:
     # Manually compile MG5aMC_PY8_interface.cc instead of using compile.py
     - echo "DEBUG DEBUG"
-    - echo "$CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS $(pythia8-config --cxxflags) $LDFLAGS $(pythia8-config --ldflags) -lHepMC"
-    - $CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS $(pythia8-config --cxxflags) $LDFLAGS $(pythia8-config --ldflags) -lHepMC
+    - echo "$CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS -pthread -DGZIP $LDFLAGS -lpythia8 -lz -lHepMC"
+    - $CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS -pthread -DGZIP $LDFLAGS -lpythia8 -lz -lHepMC
     - if: osx
       then: otool -L ./MG5aMC_PY8_interface
       else: readelf -d ./MG5aMC_PY8_interface

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -22,11 +22,11 @@ build:
     # Manually compile MG5aMC_PY8_interface.cc instead of using compile.py
     - echo "DEBUG DEBUG"
     - echo "$CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS $(pythia8-config --cxxflags) $LDFLAGS $(pythia8-config --ldflags) -lHepMC"
+    - $CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS $(pythia8-config --cxxflags) $LDFLAGS $(pythia8-config --ldflags) -lHepMC
     - if: osx
       then: otool -L ./MG5aMC_PY8_interface
       else: readelf -d ./MG5aMC_PY8_interface
     - echo "DEBUG DEBUG"
-    - $CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS $(pythia8-config --cxxflags) $LDFLAGS $(pythia8-config --ldflags) -lHepMC
     - echo "UNSPECIFIED" > MG5AMC_VERSION_ON_INSTALL
     # pythia8-config --version added in 8.312, so fall back to
     # get_pythia8_version.py for v8.311.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -34,16 +34,25 @@ build:
       then: python ./get_pythia8_version.py $PREFIX > PYTHIA8_VERSION_ON_INSTALL
       else: pythia8-config --version > PYTHIA8_VERSION_ON_INSTALL
 
-    # Install in location mg5amcnlo expects
-    - mkdir -p $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface
-    - cp MG5aMC_PY8_interface *.h VERSION COMPATIBILITY PYTHIA8_VERSION_ON_INSTALL MG5AMC_VERSION_ON_INSTALL $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/
-    # # Be optimistic about future compatibility
-    # - mkdir -p $PREFIX/include/mg5amcnlo_pythia8_interface/
-    # - mkdir -p $PREFIX/share/mg5amcnlo_pythia8_interface/
+    - mkdir -p $PREFIX/include/mg5amcnlo_pythia8_interface/
+    - mkdir -p $PREFIX/share/mg5amcnlo_pythia8_interface/
 
-    # - mv MG5aMC_PY8_interface $PREFIX/bin/
-    # - mv *.h $PREFIX/include/mg5amcnlo_pythia8_interface/
-    # - mv *.dat VERSION COMPATIBILITY PYTHIA8_VERSION_ON_INSTALL MG5AMC_VERSION_ON_INSTALL $PREFIX/share/mg5amcnlo_pythia8_interface/
+    - mv MG5aMC_PY8_interface $PREFIX/bin/
+    - mv *.h $PREFIX/include/mg5amcnlo_pythia8_interface/
+    - mv *.dat VERSION COMPATIBILITY PYTHIA8_VERSION_ON_INSTALL MG5AMC_VERSION_ON_INSTALL $PREFIX/share/mg5amcnlo_pythia8_interface/
+
+    # Symlink to location mg5amcnlo expects
+    - mkdir -p $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface
+
+    - ln -s $PREFIX/bin/MG5aMC_PY8_interface $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/
+    - ln -s $PREFIX/include/mg5amcnlo_pythia8_interface/MultiHist.h $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/
+    - ln -s $PREFIX/include/mg5amcnlo_pythia8_interface/SyscalcVeto.h $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/
+    - ln -s $PREFIX/share/mg5amcnlo_pythia8_interface/VERSION $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/VERSION
+    - ln -s $PREFIX/share/mg5amcnlo_pythia8_interface/COMPATIBILITY $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/COMPATIBILITY
+    - ln -s $PREFIX/share/mg5amcnlo_pythia8_interface/MG5AMC_VERSION_ON_INSTALL $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/MG5AMC_VERSION_ON_INSTALL
+    - ln -s $PREFIX/share/mg5amcnlo_pythia8_interface/PYTHIA8_VERSION_ON_INSTALL $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/PYTHIA8_VERSION_ON_INSTALL
+
+    - ls -lhra $PREFIX/MG5_aMC/HEPTools/MG5aMC_PY8_interface/
 
 requirements:
   build:
@@ -67,7 +76,17 @@ requirements:
 tests:
   - package_contents:
       strict: true
+      bin:
+        - MG5aMC_PY8_interface
+      include:
+        - mg5amcnlo_pythia8_interface/MultiHist.h
+        - mg5amcnlo_pythia8_interface/SyscalcVeto.h
       files:
+        - share/mg5amcnlo_pythia8_interface/VERSION
+        - share/mg5amcnlo_pythia8_interface/COMPATIBILITY
+        - share/mg5amcnlo_pythia8_interface/MG5AMC_VERSION_ON_INSTALL
+        - share/mg5amcnlo_pythia8_interface/PYTHIA8_VERSION_ON_INSTALL
+
         - MG5_aMC/HEPTools/MG5aMC_PY8_interface/MG5aMC_PY8_interface
         - MG5_aMC/HEPTools/MG5aMC_PY8_interface/VERSION
         - MG5_aMC/HEPTools/MG5aMC_PY8_interface/COMPATIBILITY
@@ -85,8 +104,7 @@ tests:
         - sed
     script:
       # DEBUG
-      - if: osx
-        then: find $CONDA_PREFIX/MG5_aMC -type f -exec sed -i 's/DYLD_LIBRARY_PATH/DYLD_FALLBACK_LIBRARY_PATH/g' {} +
+      - sed -i 's/shutil.copy(pythia_main,parallelization_dir)/shutil.copy(pythia_main, parallelization_dir, follow_symlinks=False)/g' $CONDA_PREFIX/MG5_aMC/madgraph/interface/madevent_interface.py
       # Download NNPDF23_lo_as_0130_qed in advance to avoid long output in CI logs
       # Somehow downloading in advance causes a compilation error on x86 Linux only in CI
       - lhapdf install NNPDF23_lo_as_0130_qed &> download_log.txt

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -22,6 +22,9 @@ build:
     # Manually compile MG5aMC_PY8_interface.cc instead of using compile.py
     - echo "DEBUG DEBUG"
     - echo "$CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS $(pythia8-config --cxxflags) $LDFLAGS $(pythia8-config --ldflags) -lHepMC"
+    - if: osx
+      then: otool -L ./MG5aMC_PY8_interface
+      else: readelf -d ./MG5aMC_PY8_interface
     - echo "DEBUG DEBUG"
     - $CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS $(pythia8-config --cxxflags) $LDFLAGS $(pythia8-config --ldflags) -lHepMC
     - echo "UNSPECIFIED" > MG5AMC_VERSION_ON_INSTALL

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -24,7 +24,7 @@ build:
     - echo "$CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS -pthread -DGZIP $LDFLAGS -lpythia8 -lz -lHepMC"
     - $CXX ./MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface $CXXFLAGS -pthread -DGZIP $LDFLAGS -lpythia8 -lz -lHepMC
     - if: osx
-      then: otool -L ./MG5aMC_PY8_interface
+      then: otool -l ./MG5aMC_PY8_interface
       else: readelf -d ./MG5aMC_PY8_interface
     - echo "DEBUG DEBUG"
     - echo "UNSPECIFIED" > MG5AMC_VERSION_ON_INSTALL

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -87,6 +87,7 @@ tests:
       # Somehow downloading in advance causes a compilation error on x86 Linux only in CI
       - lhapdf install NNPDF23_lo_as_0130_qed &> download_log.txt
       - mg5_aMC pythia8_test.mg5
+      - cat PYTHIA8_INTERFACE_MG5_RUN/run_01_tag_1_debug.log
 
 about:
   # modified University of Illinois/NCSA license

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -82,7 +82,11 @@ tests:
     requirements:
       run:
         - mg5amcnlo
+        - sed
     script:
+      # DEBUG
+      - if: osx
+        then: find $CONDA_PREFIX/MG5_aMC -type f -exec sed -i 's/DYLD_LIBRARY_PATH/DYLD_FALLBACK_LIBRARY_PATH/g' {} +
       # Download NNPDF23_lo_as_0130_qed in advance to avoid long output in CI logs
       # Somehow downloading in advance causes a compilation error on x86 Linux only in CI
       - lhapdf install NNPDF23_lo_as_0130_qed &> download_log.txt


### PR DESCRIPTION
* Debug rpath.
   - Addresses https://github.com/conda-forge/mg5amcnlo-pythia8-interface-feedstock/issues/2#issuecomment-3357272925
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
